### PR TITLE
add licence banner

### DIFF
--- a/semicolon.js
+++ b/semicolon.js
@@ -1,1 +1,9 @@
+/* Written in 2014 by Dmitry Chestnykh
+ *
+ * https://github.com/dchest/semicolon-js
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ */
 ;


### PR DESCRIPTION
To be enterprise-ready, all source files must include a licensing banner to
allow for IP audits.
